### PR TITLE
Event cropping with Head and Tail sections on Event clips

### DIFF
--- a/Sequentity.h
+++ b/Sequentity.h
@@ -353,21 +353,22 @@ static struct TimelineTheme_ {
 
 
 static struct EditorTheme_ {
-    ImVec4 background    { ImColor::HSV(0.0f, 0.00f, 0.651f) };
-    ImVec4 alternate     { ImColor::HSV(0.0f, 0.00f, 0.0f, 0.02f) };
-    ImVec4 text          { ImColor::HSV(0.0f, 0.00f, 0.950f) };
-    ImVec4 mid           { ImColor::HSV(0.0f, 0.00f, 0.600f) };
-    ImVec4 dark          { ImColor::HSV(0.0f, 0.00f, 0.498f) };
-    ImVec4 accent        { ImColor::HSV(0.0f, 0.75f, 0.750f) };
-    ImVec4 accent_light  { ImColor::HSV(0.0f, 0.5f, 1.0f, 0.1f) };
-    ImVec4 accent_dark   { ImColor::HSV(0.0f, 0.0f, 0.0f, 0.1f) };
-    ImVec4 selection     { ImColor::HSV(0.0f, 0.0f, 1.0f) };
-    ImVec4 outline       { ImColor::HSV(0.0f, 0.0f, 0.1f) };
-    ImVec4 track         { ImColor::HSV(0.0f, 0.0f, 0.6f) };
+    ImVec4 background      { ImColor::HSV(0.0f, 0.00f, 0.651f) };
+    ImVec4 alternate       { ImColor::HSV(0.0f, 0.00f, 0.0f, 0.02f) };
+    ImVec4 text            { ImColor::HSV(0.0f, 0.00f, 0.950f) };
+    ImVec4 mid             { ImColor::HSV(0.0f, 0.00f, 0.600f) };
+    ImVec4 dark            { ImColor::HSV(0.0f, 0.00f, 0.498f) };
+    ImVec4 accent          { ImColor::HSV(0.0f, 0.75f, 0.750f) };
+    ImVec4 accent_light    { ImColor::HSV(0.0f, 0.5f, 1.0f, 0.1f) };
+    ImVec4 accent_dark     { ImColor::HSV(0.0f, 0.0f, 0.0f, 0.1f) };
+    ImVec4 selection       { ImColor::HSV(0.0f, 0.0f, 1.0f) };
+    ImVec4 outline         { ImColor::HSV(0.0f, 0.0f, 0.1f) };
+    ImVec4 track           { ImColor::HSV(0.0f, 0.0f, 0.6f) };
+    ImVec4 head_tail_hover { ImColor::HSV(0.0f, 0.0f, 1.0f, 0.25f) };
 
-    ImVec4 start_time    { ImColor::HSV(0.33f, 0.0f, 0.25f) };
-    ImVec4 current_time  { ImColor::HSV(0.6f, 0.5f, 0.5f) };
-    ImVec4 end_time      { ImColor::HSV(0.0f, 0.0f, 0.25f) };
+    ImVec4 start_time      { ImColor::HSV(0.33f, 0.0f, 0.25f) };
+    ImVec4 current_time    { ImColor::HSV(0.6f, 0.5f, 0.5f) };
+    ImVec4 end_time        { ImColor::HSV(0.0f, 0.0f, 0.25f) };
     
     float radius { 0.0f };
     float spacing { 1.0f };
@@ -1052,7 +1053,7 @@ void EventEditor(entt::registry& registry) {
                         painter->AddRectFilled(
                             cursor + pos,
                             cursor + pos + head_tail_size,
-                            ImColor(255, 255, 255, 100), EditorTheme.radius
+                            ImColor(EditorTheme.head_tail_hover), EditorTheme.radius
                         );
                         ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
                     }
@@ -1062,7 +1063,7 @@ void EventEditor(entt::registry& registry) {
                         painter->AddRectFilled(
                             cursor + tail_pos,
                             cursor + tail_pos + head_tail_size,
-                            ImColor(255, 255, 255, 100), EditorTheme.radius
+                            ImColor(EditorTheme.head_tail_hover), EditorTheme.radius
                         );
                         ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
                     }
@@ -1389,6 +1390,7 @@ void ThemeEditor(bool* p_open) {
             ImGui::ColorEdit4("mid##editor", &EditorTheme.mid.x);
             ImGui::ColorEdit4("dark##editor", &EditorTheme.dark.x);
             ImGui::ColorEdit4("accent##editor", &EditorTheme.accent.x);
+            ImGui::ColorEdit4("head_tail_hover##editor", &EditorTheme.head_tail_hover.x);
 
             ImGui::ColorEdit4("start_time##editor", &EditorTheme.start_time.x);
             ImGui::ColorEdit4("current_time##editor", &EditorTheme.current_time.x);

--- a/Sequentity.h
+++ b/Sequentity.h
@@ -371,7 +371,7 @@ static struct EditorTheme_ {
     
     float radius { 0.0f };
     float spacing { 1.0f };
-	float head_tail_handle_width { 10.0f };
+	ImVec2 head_tail_handle_width { 10.0f, 100.0f };
     float active_clip_raise { 5.0f };
     float active_clip_raise_shadow_movement { 0.25f };
 
@@ -886,7 +886,13 @@ void EventEditor(entt::registry& registry) {
                     ImVec2 pos { time_to_px(event.time), 0.0f };
                     ImVec2 size { time_to_px(event.length), state.zoom[1] };
 
-                	ImVec2 head_tail_size{ EditorTheme.head_tail_handle_width, size.y };
+                	ImVec2 head_tail_size
+                	{
+                		std::min(EditorTheme.head_tail_handle_width.y,
+                			std::max(EditorTheme.head_tail_handle_width.x, size.x / 6)
+                        ),
+                		size.y
+                	};
                     ImVec2 tail_pos{ pos.x + size.x - head_tail_size.x , pos.y };
 
                     ImVec2 body_pos{ pos.x + head_tail_size.x, pos.y };
@@ -1390,9 +1396,9 @@ void ThemeEditor(bool* p_open) {
         	
             ImGui::DragFloat("radius##editor", &EditorTheme.radius);
             ImGui::DragFloat("spacing##editor", &EditorTheme.spacing);
-            ImGui::DragFloat("head_tail_handle_width##editor", &EditorTheme.head_tail_handle_width);
-            ImGui::DragFloat("active_clip_raise##editor", &EditorTheme.active_clip_raise);
-            ImGui::DragFloat("active_clip_raise_shadow_movement##editor", &EditorTheme.active_clip_raise_shadow_movement);
+            ImGui::DragFloat2("head_tail_handle_width##editor", &EditorTheme.head_tail_handle_width.x);
+            ImGui::DragFloat("active_clip_raise##editor", &EditorTheme.active_clip_raise, 0.1);
+            ImGui::DragFloat("active_clip_raise_shadow_movement##editor", &EditorTheme.active_clip_raise_shadow_movement, 0.01);
         }
 
         if (ImGui::CollapsingHeader("Lister")) {

--- a/Sequentity.h
+++ b/Sequentity.h
@@ -372,6 +372,7 @@ static struct EditorTheme_ {
     float radius { 0.0f };
     float spacing { 1.0f };
 	float head_tail_handle_width { 10.0f };
+    float active_clip_raise { 5.0f };
 
 } EditorTheme;
 
@@ -930,7 +931,7 @@ void EventEditor(entt::registry& registry) {
                             );
 
                         event.enabled = !event.removed;
-                        target_height = 5.0f;
+                        target_height = EditorTheme.active_clip_raise / 2;
                     }
                 	#pragma endregion EventHead
 
@@ -956,7 +957,7 @@ void EventEditor(entt::registry& registry) {
                             );
                     	
                         event.enabled = !event.removed;
-                        target_height = 5.0f;
+                        target_height = EditorTheme.active_clip_raise / 2;
                     }
 					#pragma endregion EventTail
                 	
@@ -995,7 +996,7 @@ void EventEditor(entt::registry& registry) {
 	                    );
 
 	                    event.enabled = !event.removed;
-	                    target_height = 5.0f;
+	                    target_height = EditorTheme.active_clip_raise;
                     }
 					#pragma endregion EventBody
 

--- a/Sequentity.h
+++ b/Sequentity.h
@@ -1387,6 +1387,12 @@ void ThemeEditor(bool* p_open) {
             ImGui::ColorEdit4("start_time##editor", &EditorTheme.start_time.x);
             ImGui::ColorEdit4("current_time##editor", &EditorTheme.current_time.x);
             ImGui::ColorEdit4("end_time##editor", &EditorTheme.end_time.x);
+        	
+            ImGui::DragFloat("radius##editor", &EditorTheme.radius);
+            ImGui::DragFloat("spacing##editor", &EditorTheme.spacing);
+            ImGui::DragFloat("head_tail_handle_width##editor", &EditorTheme.head_tail_handle_width);
+            ImGui::DragFloat("active_clip_raise##editor", &EditorTheme.active_clip_raise);
+            ImGui::DragFloat("active_clip_raise_shadow_movement##editor", &EditorTheme.active_clip_raise_shadow_movement);
         }
 
         if (ImGui::CollapsingHeader("Lister")) {

--- a/Sequentity.h
+++ b/Sequentity.h
@@ -372,7 +372,7 @@ static struct EditorTheme_ {
     
     float radius { 0.0f };
     float spacing { 1.0f };
-	ImVec2 head_tail_handle_width { 10.0f, 100.0f };
+    ImVec2 head_tail_handle_width { 10.0f, 100.0f };
     float active_clip_raise { 5.0f };
     float active_clip_raise_shadow_movement { 0.25f };
 
@@ -887,13 +887,13 @@ void EventEditor(entt::registry& registry) {
                     ImVec2 pos { time_to_px(event.time), 0.0f };
                     ImVec2 size { time_to_px(event.length), state.zoom[1] };
 
-                	ImVec2 head_tail_size
-                	{
-                		std::min(EditorTheme.head_tail_handle_width.y,
-                			std::max(EditorTheme.head_tail_handle_width.x, size.x / 6)
+                    ImVec2 head_tail_size
+                    {
+                        std::min(EditorTheme.head_tail_handle_width.y,
+                            std::max(EditorTheme.head_tail_handle_width.x, size.x / 6)
                         ),
-                		size.y
-                	};
+                        size.y
+                    };
                     ImVec2 tail_pos{ pos.x + size.x - head_tail_size.x , pos.y };
 
                     ImVec2 body_pos{ pos.x + head_tail_size.x, pos.y };
@@ -916,7 +916,7 @@ void EventEditor(entt::registry& registry) {
                     ImGui::PushID(track.label);
                     ImGui::PushID(event_count);
 
-                	#pragma region EventHead
+                    #pragma region EventHead
                     ImGui::SetCursorPos(cursor + pos - ImGui::GetWindowPos());
                     ImGui::SetItemAllowOverlap();
                     ImGui::InvisibleButton("##event_head", head_tail_size);
@@ -925,14 +925,14 @@ void EventEditor(entt::registry& registry) {
 
                     if (ImGui::IsItemActivated()) {
                         initial_time = event.time;
-                    	initial_length = event.length;
+                        initial_length = event.length;
                         state.selected_event = &event;
                     }
 
                     if (!ImGui::GetIO().KeyAlt && ImGui::IsItemActive()) {
                         float delta = ImGui::GetMouseDragDelta().x;
                         event.time = initial_time + px_to_time(delta);
-                    	event.length = initial_length - px_to_time(delta);
+                        event.length = initial_length - px_to_time(delta);
                         event.removed = (
                             event.time > state.range[1] ||
                             event.time + event.length < state.range[0]
@@ -941,9 +941,9 @@ void EventEditor(entt::registry& registry) {
                         event.enabled = !event.removed;
                         target_height = EditorTheme.active_clip_raise / 2;
                     }
-                	#pragma endregion EventHead
+                    #pragma endregion EventHead
 
-					#pragma region EventTail
+                    #pragma region EventTail
                     ImGui::SetCursorPos(cursor + tail_pos - ImGui::GetWindowPos());
                     ImGui::SetItemAllowOverlap();
                     ImGui::InvisibleButton("##event_tail", head_tail_size);
@@ -963,13 +963,13 @@ void EventEditor(entt::registry& registry) {
                             event.time > state.range[1] ||
                             event.time + event.length < state.range[0]
                             );
-                    	
+                        
                         event.enabled = !event.removed;
                         target_height = EditorTheme.active_clip_raise / 2;
                     }
-					#pragma endregion EventTail
-                	
-                	#pragma region EventBody
+                    #pragma endregion EventTail
+                    
+                    #pragma region EventBody
                     ImGui::SetCursorPos(cursor + body_pos - ImGui::GetWindowPos());
                     ImGui::SetItemAllowOverlap();
                     ImGui::InvisibleButton("##event", body_size);
@@ -980,74 +980,74 @@ void EventEditor(entt::registry& registry) {
                     ImVec4 color = channel.color;
 
                     if (!event.enabled || track.mute || track._notsoloed) {
-	                    color = ImColor::HSV(0.0f, 0.0f, 0.5f);
+                        color = ImColor::HSV(0.0f, 0.0f, 0.5f);
                     }
 
                     else if (ImGui::IsItemHovered() || ImGui::IsItemActive()) {
-	                    ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
-	                    target_thickness = 2.0f;
+                        ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
+                        target_thickness = 2.0f;
                     }
 
                     // User Input
                     if (ImGui::IsItemActivated()) {
-	                    initial_time = event.time;
+                        initial_time = event.time;
                         initial_length = event.length;
-	                    state.selected_event = &event;
+                        state.selected_event = &event;
                     }
 
                     if (!ImGui::GetIO().KeyAlt && ImGui::IsItemActive()) {
-	                    float delta = ImGui::GetMouseDragDelta().x;
-	                    event.time = initial_time + px_to_time(delta);
-	                    event.removed = (
-		                    event.time > state.range[1] ||
-		                    event.time + event.length < state.range[0]
-	                    );
+                        float delta = ImGui::GetMouseDragDelta().x;
+                        event.time = initial_time + px_to_time(delta);
+                        event.removed = (
+                            event.time > state.range[1] ||
+                            event.time + event.length < state.range[0]
+                        );
 
-	                    event.enabled = !event.removed;
-	                    target_height = EditorTheme.active_clip_raise;
+                        event.enabled = !event.removed;
+                        target_height = EditorTheme.active_clip_raise;
                     }
-					#pragma endregion EventBody
+                    #pragma endregion EventBody
 
                     _transition(event.height, target_height, CommonTheme.transition_speed);
                     pos -= event.height;
                     tail_pos -= event.height;
 
                     const int shadow = 2;
-                	float shadow_movement = event.height * (1.0f + EditorTheme.active_clip_raise_shadow_movement);
+                    float shadow_movement = event.height * (1.0f + EditorTheme.active_clip_raise_shadow_movement);
                     painter->AddRectFilled(
-	                    cursor + pos + shadow + shadow_movement,
+                        cursor + pos + shadow + shadow_movement,
                         cursor + pos + size + shadow + shadow_movement,
-	                    ImColor::HSV(0.0f, 0.0f, 0.0f, 0.3f), EditorTheme.radius
+                        ImColor::HSV(0.0f, 0.0f, 0.0f, 0.3f), EditorTheme.radius
                     );
 
                     painter->AddRectFilled(
-	                    cursor + pos,
-	                    cursor + pos + size,
-	                    ImColor(color), EditorTheme.radius
+                        cursor + pos,
+                        cursor + pos + size,
+                        ImColor(color), EditorTheme.radius
                     );
 
                     // Add a dash to the bottom of each event.
                     painter->AddRectFilled(
-	                    cursor + pos + ImVec2{ 0.0f, size.y - 5.0f },
-	                    cursor + pos + size,
-	                    ImColor(color * 0.8f), EditorTheme.radius
+                        cursor + pos + ImVec2{ 0.0f, size.y - 5.0f },
+                        cursor + pos + size,
+                        ImColor(color * 0.8f), EditorTheme.radius
                     );
 
                     if (ImGui::IsItemHovered() || ImGui::IsItemActive() || head_hovered || tail_hovered || state.selected_event == &event) {
-	                    painter->AddRect(
-		                    cursor + pos        + event.thickness * 0.25f,
-		                    cursor + pos + size - event.thickness * 0.25f,
-		                    ImColor(EditorTheme.selection), EditorTheme.radius, ImDrawCornerFlags_All, event.thickness
-	                    );
+                        painter->AddRect(
+                            cursor + pos        + event.thickness * 0.25f,
+                            cursor + pos + size - event.thickness * 0.25f,
+                            ImColor(EditorTheme.selection), EditorTheme.radius, ImDrawCornerFlags_All, event.thickness
+                        );
                     }
                     else {
-	                    painter->AddRect(
-		                    cursor + pos        + event.thickness,
-		                    cursor + pos + size - event.thickness,
-		                    ImColor(EditorTheme.outline), EditorTheme.radius
-	                    );
+                        painter->AddRect(
+                            cursor + pos        + event.thickness,
+                            cursor + pos + size - event.thickness,
+                            ImColor(EditorTheme.outline), EditorTheme.radius
+                        );
                     }
-                	
+                    
                     if (head_hovered)
                     {
                         painter->AddRectFilled(
@@ -1069,27 +1069,27 @@ void EventEditor(entt::registry& registry) {
                     }
 
                     if (event.enabled) {
-	                    if (ImGui::IsItemHovered() || ImGui::IsItemActive() || head_hovered || tail_hovered) {
-		                    if (event.length > 5.0f) {
-			                    painter->AddText(
-				                    ImGui::GetFont(),
-				                    ImGui::GetFontSize() * 0.85f,
-				                    cursor + pos + ImVec2{ 3.0f + event.thickness, 0.0f },
-				                    ImColor(EditorTheme.text),
-				                    std::to_string(event.time).c_str()
-			                    );
-		                    }
+                        if (ImGui::IsItemHovered() || ImGui::IsItemActive() || head_hovered || tail_hovered) {
+                            if (event.length > 5.0f) {
+                                painter->AddText(
+                                    ImGui::GetFont(),
+                                    ImGui::GetFontSize() * 0.85f,
+                                    cursor + pos + ImVec2{ 3.0f + event.thickness, 0.0f },
+                                    ImColor(EditorTheme.text),
+                                    std::to_string(event.time).c_str()
+                                );
+                            }
                         
-		                    if (event.length > 30.0f) {
-			                    painter->AddText(
-				                    ImGui::GetFont(),
-				                    ImGui::GetFontSize() * 0.85f,
-				                    cursor + pos + ImVec2{ size.x - 20.0f, 0.0f },
-				                    ImColor(EditorTheme.text),
-				                    std::to_string(event.length).c_str()
-			                    );
-		                    }
-	                    }
+                            if (event.length > 30.0f) {
+                                painter->AddText(
+                                    ImGui::GetFont(),
+                                    ImGui::GetFontSize() * 0.85f,
+                                    cursor + pos + ImVec2{ size.x - 20.0f, 0.0f },
+                                    ImColor(EditorTheme.text),
+                                    std::to_string(event.length).c_str()
+                                );
+                            }
+                        }
                     }
 
                     event_count++;
@@ -1395,7 +1395,7 @@ void ThemeEditor(bool* p_open) {
             ImGui::ColorEdit4("start_time##editor", &EditorTheme.start_time.x);
             ImGui::ColorEdit4("current_time##editor", &EditorTheme.current_time.x);
             ImGui::ColorEdit4("end_time##editor", &EditorTheme.end_time.x);
-        	
+            
             ImGui::DragFloat("radius##editor", &EditorTheme.radius);
             ImGui::DragFloat("spacing##editor", &EditorTheme.spacing);
             ImGui::DragFloat2("head_tail_handle_width##editor", &EditorTheme.head_tail_handle_width.x);

--- a/Sequentity.h
+++ b/Sequentity.h
@@ -903,7 +903,7 @@ void EventEditor(entt::registry& registry) {
                     float target_height { 0.0f };
                     float target_thickness = 0.0f;
 
-                    /** TO REVIEW: Implement crop interaction and visualisation
+                    /** Implement crop interaction and visualisation
                          ____________________________________
                         |      |                      |      |
                         | head |         body         | tail |

--- a/Sequentity.h
+++ b/Sequentity.h
@@ -373,6 +373,7 @@ static struct EditorTheme_ {
     float spacing { 1.0f };
 	float head_tail_handle_width { 10.0f };
     float active_clip_raise { 5.0f };
+    float active_clip_raise_shadow_movement { 0.25f };
 
 } EditorTheme;
 
@@ -1005,9 +1006,10 @@ void EventEditor(entt::registry& registry) {
                     tail_pos -= event.height;
 
                     const int shadow = 2;
+                	float shadow_movement = event.height * (1.0f + EditorTheme.active_clip_raise_shadow_movement);
                     painter->AddRectFilled(
-	                    cursor + pos + shadow + event.height * 1.25f,
-	                    cursor + pos + size + shadow + event.height * 1.25f,
+	                    cursor + pos + shadow + shadow_movement,
+                        cursor + pos + size + shadow + shadow_movement,
 	                    ImColor::HSV(0.0f, 0.0f, 0.0f, 0.3f), EditorTheme.radius
                     );
 


### PR DESCRIPTION
Hi!

I'd use Sequentity in our demotool, as seemingly this is the most mature one out there for ImGui I could find. However we'd needed to modify Event ranges from the GUI (instead of PushEvent). So I took a day and done this pull-request. I've seen there were already plans to make it, I hope what I did aligns with those plans actually.

![sequentity-trimming](https://user-images.githubusercontent.com/1009962/81508170-d6222100-9302-11ea-826b-28eef62ec7b2.gif)

One caveat I haven't payed too much attention to yet: the Example application resets event.length during playback, when the current time hits the start of the event, I hope that's coming from the example application and not from Sequentity itself, if that's the case, sorry for my oversight, I'm not yet too familiar with Entt (seems to be nice thing tho, as I can see from the Example code)

So as you can see I haven't touched the Example application actually to deal with changeable event length.

I hope you like it, if you have any feedback, I can try to fix it or conform to it.